### PR TITLE
fix: update ossf/scorecard-action to official v2.4.3 commit

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@ff5dd8929f96a8a4dc67d13f32b8c75057829621 # v2.4.0
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary
- Update `ossf/scorecard-action` pin from `ff5dd89...` (v2.4.0) to `4eaacf0...` (v2.4.3)
- The previous commit hash was rejected by the OpenSSF webapp as an "imposter commit" not belonging to `ossf/scorecard-action`, causing the Scorecard Analysis CI job to fail

## Test plan
- [ ] Verify the Scorecard Analysis workflow passes on the next push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)