### PR TITLE
feat: add descope_project data source

### DIFF
--- a/internal/datasources/project.go
+++ b/internal/datasources/project.go
@@ -1,0 +1,180 @@
+package datasources
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/descope/terraform-provider-descope/internal/infra"
+	"github.com/descope/terraform-provider-descope/internal/models/helpers"
+	"github.com/descope/terraform-provider-descope/internal/models/project"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	dsschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	rsschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ datasource.DataSource              = &projectDataSource{}
+	_ datasource.DataSourceWithConfigure = &projectDataSource{}
+)
+
+func NewProjectDataSource() datasource.DataSource {
+	return &projectDataSource{}
+}
+
+type projectDataSource struct {
+	client *infra.Client
+}
+
+func (d *projectDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {
+	if data, ok := req.ProviderData.(*infra.ProviderData); ok {
+		d.client = data.Client
+	}
+}
+
+func (d *projectDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_project"
+}
+
+func (d *projectDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	attrs := toComputedAttributes(project.ProjectAttributes)
+
+	// Override id to be the required lookup key
+	attrs["id"] = dsschema.StringAttribute{
+		Required: true,
+	}
+
+	resp.Schema = dsschema.Schema{
+		Attributes: attrs,
+	}
+}
+
+func (d *projectDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	tflog.Info(ctx, "Reading project data source")
+
+	var id types.String
+	if resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("id"), &id)...); resp.Diagnostics.HasError() {
+		return
+	}
+
+	projectID := id.ValueString()
+
+	res, err := d.client.Read(ctx, projectID, "project", projectID)
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading project", err.Error())
+		return
+	}
+
+	// Mark context so ShouldSetAttributeValue allows populating null fields
+	ctx = helpers.ContextForDataSource(ctx)
+
+	model := &project.ProjectModel{}
+	model.ID = types.StringValue(projectID)
+
+	handler := helpers.NewHandler(ctx, &resp.Diagnostics)
+	model.CollectReferences(handler)
+	model.SetValues(handler, res.Data)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	model.CollectReferences(handler)
+	model.UpdateReferences(handler)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
+	tflog.Info(ctx, "Project data source read")
+}
+
+// toComputedAttributes converts resource schema attributes to data source
+// schema attributes with all fields set to Computed.
+func toComputedAttributes(attrs map[string]rsschema.Attribute) map[string]dsschema.Attribute {
+	result := make(map[string]dsschema.Attribute, len(attrs))
+	for name, attr := range attrs {
+		result[name] = toComputedAttribute(attr)
+	}
+	return result
+}
+
+func toComputedAttribute(attr rsschema.Attribute) dsschema.Attribute {
+	switch a := attr.(type) {
+	case rsschema.StringAttribute:
+		return dsschema.StringAttribute{
+			Computed:   true,
+			Sensitive:  a.Sensitive,
+			CustomType: a.CustomType,
+		}
+	case rsschema.Int64Attribute:
+		return dsschema.Int64Attribute{
+			Computed:   true,
+			CustomType: a.CustomType,
+		}
+	case rsschema.BoolAttribute:
+		return dsschema.BoolAttribute{
+			Computed: true,
+		}
+	case rsschema.Float64Attribute:
+		return dsschema.Float64Attribute{
+			Computed:   true,
+			CustomType: a.CustomType,
+		}
+	case rsschema.NumberAttribute:
+		return dsschema.NumberAttribute{
+			Computed:   true,
+			CustomType: a.CustomType,
+		}
+	case rsschema.SetAttribute:
+		return dsschema.SetAttribute{
+			Computed:    true,
+			ElementType: a.ElementType,
+			CustomType:  a.CustomType,
+		}
+	case rsschema.ListAttribute:
+		return dsschema.ListAttribute{
+			Computed:    true,
+			ElementType: a.ElementType,
+			CustomType:  a.CustomType,
+		}
+	case rsschema.MapAttribute:
+		return dsschema.MapAttribute{
+			Computed:    true,
+			ElementType: a.ElementType,
+			CustomType:  a.CustomType,
+		}
+	case rsschema.SingleNestedAttribute:
+		return dsschema.SingleNestedAttribute{
+			Computed:   true,
+			Attributes: toComputedAttributes(a.Attributes),
+			CustomType: a.CustomType,
+		}
+	case rsschema.ListNestedAttribute:
+		return dsschema.ListNestedAttribute{
+			Computed: true,
+			NestedObject: dsschema.NestedAttributeObject{
+				Attributes: toComputedAttributes(a.NestedObject.Attributes),
+				CustomType: a.NestedObject.CustomType,
+			},
+			CustomType: a.CustomType,
+		}
+	case rsschema.MapNestedAttribute:
+		return dsschema.MapNestedAttribute{
+			Computed: true,
+			NestedObject: dsschema.NestedAttributeObject{
+				Attributes: toComputedAttributes(a.NestedObject.Attributes),
+				CustomType: a.NestedObject.CustomType,
+			},
+			CustomType: a.CustomType,
+		}
+	case rsschema.SetNestedAttribute:
+		return dsschema.SetNestedAttribute{
+			Computed: true,
+			NestedObject: dsschema.NestedAttributeObject{
+				Attributes: toComputedAttributes(a.NestedObject.Attributes),
+				CustomType: a.NestedObject.CustomType,
+			},
+			CustomType: a.CustomType,
+		}
+	default:
+		panic(fmt.Sprintf("unsupported attribute type for data source conversion: %T", attr))
+	}
+}

--- a/internal/models/helpers/import.go
+++ b/internal/models/helpers/import.go
@@ -30,6 +30,13 @@ func ContextWithImportState(ctx context.Context, req resource.ReadRequest, resp 
 	return ctx
 }
 
+// ContextForDataSource marks the context to allow all null attribute values
+// to be overwritten. Data source reads behave like imports: all attributes
+// start as null and need to be populated from the API response.
+func ContextForDataSource(ctx context.Context) context.Context {
+	return context.WithValue(ctx, importKey, true)
+}
+
 // Checks if we're currently reading a source as part of an import operation.
 func isImportState(ctx context.Context) bool {
 	value, _ := ctx.Value(importKey).(bool)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 
+	"github.com/descope/terraform-provider-descope/internal/datasources"
 	"github.com/descope/terraform-provider-descope/internal/infra"
 	"github.com/descope/terraform-provider-descope/internal/resources"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -115,7 +116,9 @@ func (p *descopeProvider) Configure(ctx context.Context, req provider.ConfigureR
 }
 
 func (p *descopeProvider) DataSources(_ context.Context) []func() datasource.DataSource {
-	return []func() datasource.DataSource{}
+	return []func() datasource.DataSource{
+		datasources.NewProjectDataSource,
+	}
 }
 
 func (p *descopeProvider) Resources(_ context.Context) []func() resource.Resource {

--- a/tests/integration/project_data_test.go
+++ b/tests/integration/project_data_test.go
@@ -1,0 +1,34 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProjectDataSource(t *testing.T) {
+	h := NewHarness(t)
+	name := GenerateName(t)
+	nameVar := "name=" + name
+
+	// Create a project and read it back via data source
+	h.LoadFixture("project_data/read.tf")
+	h.Apply(nameVar)
+
+	// Verify the resource
+	resAttrs := h.StateResource("descope_project.test")
+	require.NotEmpty(t, resAttrs["id"])
+	assert.Equal(t, name, resAttrs["name"])
+
+	// Verify the data source reads the same project
+	dataAttrs := h.StateResource("data.descope_project.test")
+	assert.Equal(t, resAttrs["id"], dataAttrs["id"])
+	assert.Equal(t, name, dataAttrs["name"])
+
+	// Destroy
+	h.Destroy(nameVar)
+	assert.False(t, h.HasState())
+}

--- a/tests/integration/testdata/project_data/read.tf
+++ b/tests/integration/testdata/project_data/read.tf
@@ -1,0 +1,9 @@
+variable "name" { type = string }
+
+resource "descope_project" "test" {
+  name = var.name
+}
+
+data "descope_project" "test" {
+  id = descope_project.test.id
+}


### PR DESCRIPTION
## Summary
- Adds `data "descope_project"` data source that reads an existing project by ID
- Recursive `toComputedAttributes` schema converter transforms the full resource schema to read-only
- Reuses import context mechanism (`ContextForDataSource`) to populate null attributes from API responses
- Integration test validates data source reads match resource values

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] Integration test `TestProjectDataSource` passes
- [x] Full integration suite (15/15 tests) passes

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)