### PR TITLE
chore: merge upstream descope/terraform-provider-descope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,9 @@ jobs:
         with:
           terraform_wrapper: false
       - name: Install Descope CLI
-        uses: descope/descopecli/.github/actions/install@0b0424bac0d766f9e7d5f919e85fe60f17066691 # v0.8.14
+        uses: descope/descopecli/.github/actions/install@76722efc17408640a42340cbdae1528c363e9dc2 # v0.8.15
       - name: Run Integration Tests
+        shell: bash
         env:
           DESCOPE_MANAGEMENT_KEY: ${{ secrets.DESCOPE_MANAGEMENT_KEY }}
           DESCOPE_PROJECT_ID: ${{ secrets.DESCOPE_PROJECT_ID }}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/descope/terraform-provider-descope
 go 1.26
 
 require (
-	github.com/descope/go-sdk v1.11.0
+	github.com/descope/go-sdk v1.13.0
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/terraform-plugin-framework v1.18.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 h1:NMZiJj8QnKe1LgsbDayM4UoHwbvwDRwnI3hwNaAHRnc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
-github.com/descope/go-sdk v1.11.0 h1:e8iFNelZbLrqzBppNUuHFztUDQOQoZrmFhTqQ9JCCRc=
-github.com/descope/go-sdk v1.11.0/go.mod h1:lCwCgYOfrgjANMsR2BVe1yfX0Siwd2NjNAig0myWZqY=
+github.com/descope/go-sdk v1.13.0 h1:Bp9Yg70K0658w/Hac8lrtOHIWxK69jw8uQRHtV3OYBg=
+github.com/descope/go-sdk v1.13.0/go.mod h1:lCwCgYOfrgjANMsR2BVe1yfX0Siwd2NjNAig0myWZqY=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=


### PR DESCRIPTION
## Summary
- Merge latest commits from upstream `descope/terraform-provider-descope` into fork
- Includes: go-sdk v1.13.0 bump, descopecli v0.8.14→v0.8.15, golangci-lint v2.10.1, setup-go v6, and CI updates
- Merge conflicts resolved: kept our newer golangci-lint (v2.11.1) and setup-go (v6.3.0) versions, took upstream's descopecli bump and `shell: bash` addition

## Upstream commits
- `ci(action): update descope/descopecli action to v0.8.15 (#262)`
- `fix(deps): update module github.com/descope/go-sdk to v1.13.0 (#261)`
- `chore(deps): update dependency golangci/golangci-lint to v2.10.1 (#260)`
- `ci(action): update actions/setup-go action to v6 (#192)`
- `ci(action): update descope/descopecli action to v0.8.14 (#254)`

## Test plan
- [ ] CI passes with updated dependencies
- [ ] Provider builds and unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)