### PR TITLE
feat: add descope_outbound_application resource

### DIFF
--- a/docs/resources/outbound_application.md
+++ b/docs/resources/outbound_application.md
@@ -1,0 +1,55 @@
+---
+page_title: "descope_outbound_application Resource - descope"
+subcategory: ""
+description: |-
+  Manages a Descope outbound application.
+---
+
+# descope_outbound_application (Resource)
+
+Manages a Descope outbound application for OAuth integrations with external services. Outbound applications allow Descope to act as an OAuth client, enabling users to connect their accounts with third-party services.
+
+## Example Usage
+
+```terraform
+resource "descope_outbound_application" "github" {
+  name              = "GitHub Integration"
+  description       = "OAuth integration with GitHub"
+  client_id         = "github-client-id"
+  client_secret     = var.github_client_secret
+  authorization_url = "https://github.com/login/oauth/authorize"
+  token_url         = "https://github.com/login/oauth/access_token"
+  default_scopes    = ["read:user", "user:email"]
+}
+```
+
+## Schema
+
+### Required
+
+- `name` (String) The application name.
+
+### Optional
+
+- `authorization_url` (String) OAuth authorization endpoint URL.
+- `callback_domain` (String) Callback domain override.
+- `client_id` (String) OAuth client ID.
+- `client_secret` (String, Sensitive) OAuth client secret. Write-only — not returned by the API.
+- `default_redirect_url` (String) Default redirect URL after authorization.
+- `default_scopes` (Set of String) Default OAuth scopes to request.
+- `description` (String) Application description.
+- `discovery_url` (String) OIDC discovery URL for auto-configuration.
+- `logo` (String) Application logo URL.
+- `pkce` (Boolean) Enable PKCE for the OAuth flow. Defaults to `false`.
+- `revocation_url` (String) Token revocation endpoint URL.
+- `token_url` (String) OAuth token endpoint URL.
+
+### Read-Only
+
+- `id` (String) The application identifier.
+
+## Import
+
+```shell
+terraform import descope_outbound_application.example "app-id-here"
+```

--- a/internal/models/outboundapp/convert.go
+++ b/internal/models/outboundapp/convert.go
@@ -1,0 +1,65 @@
+package outboundapp
+
+import (
+	"context"
+
+	"github.com/descope/go-sdk/descope"
+	"github.com/descope/terraform-provider-descope/internal/models/attrs/strsetattr"
+	"github.com/descope/terraform-provider-descope/internal/models/convert"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func ModelToCreateRequest(ctx context.Context, model *Model, diags *diag.Diagnostics) *descope.CreateOutboundAppRequest {
+	return &descope.CreateOutboundAppRequest{
+		OutboundApp:  *modelToOutboundApp(ctx, model, diags),
+		ClientSecret: model.ClientSecret.ValueString(),
+	}
+}
+
+func ModelToOutboundApp(ctx context.Context, model *Model, diags *diag.Diagnostics) *descope.OutboundApp {
+	return modelToOutboundApp(ctx, model, diags)
+}
+
+func ClientSecretPtr(model *Model) *string {
+	if model.ClientSecret.IsNull() || model.ClientSecret.IsUnknown() || model.ClientSecret.ValueString() == "" {
+		return nil
+	}
+	s := model.ClientSecret.ValueString()
+	return &s
+}
+
+func RefreshModelFromResponse(ctx context.Context, model *Model, app *descope.OutboundApp) {
+	model.ID = types.StringValue(app.ID)
+	model.Name = types.StringValue(app.Name)
+	model.Description = types.StringValue(app.Description)
+	model.ClientID = types.StringValue(app.ClientID)
+	// client_secret is write-only — not returned by API, preserve plan value
+	model.Logo = types.StringValue(app.Logo)
+	model.DiscoveryURL = types.StringValue(app.DiscoveryURL)
+	model.AuthorizationURL = types.StringValue(app.AuthorizationURL)
+	model.TokenURL = types.StringValue(app.TokenURL)
+	model.RevocationURL = types.StringValue(app.RevocationURL)
+	model.DefaultScopes = strsetattr.ValueCtx(ctx, app.DefaultScopes)
+	model.DefaultRedirectURL = types.StringValue(app.DefaultRedirectURL)
+	model.CallbackDomain = types.StringValue(app.CallbackDomain)
+	model.Pkce = types.BoolValue(app.Pkce)
+}
+
+func modelToOutboundApp(ctx context.Context, model *Model, diags *diag.Diagnostics) *descope.OutboundApp {
+	return &descope.OutboundApp{
+		ID:                 model.ID.ValueString(),
+		Name:               model.Name.ValueString(),
+		Description:        model.Description.ValueString(),
+		ClientID:           model.ClientID.ValueString(),
+		Logo:               model.Logo.ValueString(),
+		DiscoveryURL:       model.DiscoveryURL.ValueString(),
+		AuthorizationURL:   model.AuthorizationURL.ValueString(),
+		TokenURL:           model.TokenURL.ValueString(),
+		RevocationURL:      model.RevocationURL.ValueString(),
+		DefaultScopes:      convert.StringSetToSlice(ctx, model.DefaultScopes, diags),
+		DefaultRedirectURL: model.DefaultRedirectURL.ValueString(),
+		CallbackDomain:     model.CallbackDomain.ValueString(),
+		Pkce:               model.Pkce.ValueBool(),
+	}
+}

--- a/internal/models/outboundapp/outboundapp.go
+++ b/internal/models/outboundapp/outboundapp.go
@@ -1,0 +1,45 @@
+package outboundapp
+
+import (
+	"github.com/descope/terraform-provider-descope/internal/models/attrs/boolattr"
+	"github.com/descope/terraform-provider-descope/internal/models/attrs/stringattr"
+	"github.com/descope/terraform-provider-descope/internal/models/attrs/strsetattr"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+var Attributes = map[string]schema.Attribute{
+	"id":          stringattr.Identifier(),
+	"name":        stringattr.Required(),
+	"description": stringattr.Default(""),
+	"client_id":   stringattr.Default(""),
+	"client_secret": schema.StringAttribute{
+		Optional:  true,
+		Sensitive: true,
+	},
+	"logo":                 stringattr.Default(""),
+	"discovery_url":        stringattr.Default(""),
+	"authorization_url":    stringattr.Default(""),
+	"token_url":            stringattr.Default(""),
+	"revocation_url":       stringattr.Default(""),
+	"default_scopes":       strsetattr.Default(),
+	"default_redirect_url": stringattr.Default(""),
+	"callback_domain":      stringattr.Default(""),
+	"pkce":                 boolattr.Default(false),
+}
+
+type Model struct {
+	ID                 stringattr.Type `tfsdk:"id"`
+	Name               stringattr.Type `tfsdk:"name"`
+	Description        stringattr.Type `tfsdk:"description"`
+	ClientID           stringattr.Type `tfsdk:"client_id"`
+	ClientSecret       stringattr.Type `tfsdk:"client_secret"`
+	Logo               stringattr.Type `tfsdk:"logo"`
+	DiscoveryURL       stringattr.Type `tfsdk:"discovery_url"`
+	AuthorizationURL   stringattr.Type `tfsdk:"authorization_url"`
+	TokenURL           stringattr.Type `tfsdk:"token_url"`
+	RevocationURL      stringattr.Type `tfsdk:"revocation_url"`
+	DefaultScopes      strsetattr.Type `tfsdk:"default_scopes"`
+	DefaultRedirectURL stringattr.Type `tfsdk:"default_redirect_url"`
+	CallbackDomain     stringattr.Type `tfsdk:"callback_domain"`
+	Pkce               boolattr.Type   `tfsdk:"pkce"`
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -135,5 +135,6 @@ func (p *descopeProvider) Resources(_ context.Context) []func() resource.Resourc
 		resources.NewPermissionResource,
 		resources.NewRoleResource,
 		resources.NewSSOResource,
+		resources.NewOutboundAppResource,
 	}
 }

--- a/internal/resources/outboundapp.go
+++ b/internal/resources/outboundapp.go
@@ -1,0 +1,157 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/descope/go-sdk/descope"
+	"github.com/descope/go-sdk/descope/sdk"
+	"github.com/descope/terraform-provider-descope/internal/infra"
+	"github.com/descope/terraform-provider-descope/internal/models/outboundapp"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ resource.Resource                = &outboundAppResource{}
+	_ resource.ResourceWithConfigure   = &outboundAppResource{}
+	_ resource.ResourceWithImportState = &outboundAppResource{}
+)
+
+func NewOutboundAppResource() resource.Resource {
+	return &outboundAppResource{}
+}
+
+type outboundAppResource struct {
+	management sdk.Management
+}
+
+func (r *outboundAppResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+	if data, ok := req.ProviderData.(*infra.ProviderData); ok {
+		r.management = data.Management
+	}
+}
+
+func (r *outboundAppResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_outbound_application"
+}
+
+func (r *outboundAppResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Manages a Descope outbound application for OAuth integrations with external services.",
+		Attributes:  outboundapp.Attributes,
+	}
+}
+
+func (r *outboundAppResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	tflog.Info(ctx, "Creating outbound application resource")
+
+	var model outboundapp.Model
+	if resp.Diagnostics.Append(req.Plan.Get(ctx, &model)...); resp.Diagnostics.HasError() {
+		return
+	}
+
+	createReq := outboundapp.ModelToCreateRequest(ctx, &model, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	app, err := infra.RetryOnRateLimit(ctx, func() (*descope.OutboundApp, error) {
+		return r.management.OutboundApplication().CreateApplication(ctx, createReq)
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating outbound application", err.Error())
+		return
+	}
+
+	outboundapp.RefreshModelFromResponse(ctx, &model, app)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	tflog.Info(ctx, "Outbound application resource created")
+}
+
+func (r *outboundAppResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	tflog.Info(ctx, "Reading outbound application resource")
+
+	var model outboundapp.Model
+	if resp.Diagnostics.Append(req.State.Get(ctx, &model)...); resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := model.ID.ValueString()
+	app, err := infra.RetryOnRateLimit(ctx, func() (*descope.OutboundApp, error) {
+		return r.management.OutboundApplication().LoadApplication(ctx, id)
+	})
+	if err != nil {
+		if infra.IsNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Error reading outbound application", err.Error())
+		return
+	}
+
+	outboundapp.RefreshModelFromResponse(ctx, &model, app)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	tflog.Info(ctx, "Outbound application resource read")
+}
+
+func (r *outboundAppResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	tflog.Info(ctx, "Updating outbound application resource")
+
+	var plan outboundapp.Model
+	if resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...); resp.Diagnostics.HasError() {
+		return
+	}
+
+	var state outboundapp.Model
+	if resp.Diagnostics.Append(req.State.Get(ctx, &state)...); resp.Diagnostics.HasError() {
+		return
+	}
+
+	plan.ID = state.ID
+	appReq := outboundapp.ModelToOutboundApp(ctx, &plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	app, err := infra.RetryOnRateLimit(ctx, func() (*descope.OutboundApp, error) {
+		return r.management.OutboundApplication().UpdateApplication(ctx, appReq, outboundapp.ClientSecretPtr(&plan))
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("Error updating outbound application", err.Error())
+		return
+	}
+
+	outboundapp.RefreshModelFromResponse(ctx, &plan, app)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	tflog.Info(ctx, "Outbound application resource updated")
+}
+
+func (r *outboundAppResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	tflog.Info(ctx, "Deleting outbound application resource")
+
+	var model outboundapp.Model
+	if resp.Diagnostics.Append(req.State.Get(ctx, &model)...); resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := model.ID.ValueString()
+	err := infra.RetryOnRateLimitNoResult(ctx, func() error {
+		return r.management.OutboundApplication().DeleteApplication(ctx, id)
+	})
+	if err != nil {
+		if infra.IsNotFoundError(err) {
+			return
+		}
+		resp.Diagnostics.AddError("Error deleting outbound application", err.Error())
+		return
+	}
+
+	tflog.Info(ctx, "Outbound application resource deleted")
+}
+
+func (r *outboundAppResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	tflog.Info(ctx, "Importing outbound application resource")
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/tests/integration/outboundapp_test.go
+++ b/tests/integration/outboundapp_test.go
@@ -1,0 +1,29 @@
+//go:build integration || fork
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOutboundAppCRUD(t *testing.T) {
+	h := NewHarness(t)
+	name := GenerateName(t)
+	nameVar := "name=" + name
+	address := "descope_outbound_application.test"
+
+	// Create
+	attrs := h.ApplyFixture("outboundapp/create.tf", address, nameVar)
+	assert.Equal(t, name, attrs["name"])
+	assert.Equal(t, "Test outbound application", attrs["description"])
+
+	id := StringAttr(attrs, "id")
+	require.NotEmpty(t, id)
+
+	// Destroy
+	h.Destroy(nameVar)
+	assert.False(t, h.HasState())
+}

--- a/tests/integration/testdata/outboundapp/create.tf
+++ b/tests/integration/testdata/outboundapp/create.tf
@@ -1,0 +1,8 @@
+variable "name" { type = string }
+
+resource "descope_outbound_application" "test" {
+  name              = var.name
+  description       = "Test outbound application"
+  authorization_url = "https://external.example.com/authorize"
+  token_url         = "https://external.example.com/token"
+}


### PR DESCRIPTION
## Summary
- Adds `descope_outbound_application` resource for managing OAuth integrations with external services
- Core fields: name, client_id, client_secret (sensitive), authorization_url, token_url, scopes, etc.
- Full CRUD via OutboundApplication Management SDK interface
- Import by application ID

## Test plan
- [x] `go build ./...` clean
- [x] `gofmt` clean
- [x] All unit tests pass
- [ ] Integration tests (require API credentials — run in CI)

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)