### PR TITLE
docs: Descope architecture — entity model, OAuth/OIDC mapping, auth flow diagrams

### DIFF
--- a/docs/architecture/auth-flows.md
+++ b/docs/architecture/auth-flows.md
@@ -1,0 +1,204 @@
+# Authentication and Authorization Flows
+
+This document provides sequence diagrams for Descope's authentication and authorization flows.
+
+## OAuth 2.0 Authorization Code Flow (Descope as IdP)
+
+When an external application (Inbound App) uses Descope as its identity provider:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant App as Client App<br/>(Inbound App)
+    participant Descope as Descope<br/>(/authorize)
+    participant Flow as Descope Flow<br/>(Login UI)
+    participant Token as Descope<br/>(/token)
+
+    User->>App: Access protected resource
+    App->>Descope: Redirect to /authorize<br/>(client_id, redirect_uri, scope, state)
+    Descope->>Flow: Present login flow
+    Flow->>User: Show login screen
+    User->>Flow: Authenticate (password/OTP/magic link/SSO)
+    Flow->>Descope: Authentication successful
+    Note over Descope: If scopes require consent
+    Descope->>User: Show consent screen
+    User->>Descope: Approve scopes
+    Descope->>App: Redirect to redirect_uri<br/>(code, state)
+    App->>Token: POST /token<br/>(code, client_id, client_secret)
+    Token->>App: Return tokens<br/>(access_token, id_token, refresh_token)
+    App->>User: Grant access
+```
+
+## Third-Party App Consent Flow
+
+When a third-party application requests access to user data:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant ThirdParty as Third-Party App
+    participant Descope as Descope
+    participant Consent as Consent Screen
+
+    ThirdParty->>Descope: Redirect to /authorize<br/>(client_id, scopes)
+    Descope->>User: Authenticate user
+    User->>Descope: Credentials
+    Descope->>Consent: Show permission request
+    Note over Consent: "App X wants to:<br/>- Read your profile<br/>- Access your email"
+    Consent->>User: Display requested scopes
+    User->>Consent: Approve / Deny
+    alt Approved
+        Consent->>Descope: Record consent
+        Descope->>ThirdParty: Authorization code
+        ThirdParty->>Descope: Exchange for tokens
+    else Denied
+        Descope->>ThirdParty: Error: access_denied
+    end
+```
+
+## SSO / SAML Federation Flow
+
+When a tenant has SAML SSO configured:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant App as Application
+    participant Descope as Descope (SP)
+    participant IdP as Enterprise IdP<br/>(Okta/Azure AD)
+
+    User->>App: Click "Sign in with SSO"
+    App->>Descope: Initiate SSO<br/>(tenant_id)
+    Descope->>IdP: SAML AuthnRequest
+    IdP->>User: Show enterprise login
+    User->>IdP: Enter corporate credentials
+    IdP->>User: MFA challenge (if configured)
+    User->>IdP: Complete MFA
+    IdP->>Descope: SAML Response<br/>(assertions, attributes)
+    Descope->>Descope: Validate signature,<br/>map attributes to user,<br/>apply role mappings
+    Descope->>App: Session tokens<br/>(JWT with roles/permissions)
+    App->>User: Authenticated session
+```
+
+## Standard Authentication Flow
+
+Direct authentication without OAuth (SDK-based):
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant App as Application<br/>(Descope SDK)
+    participant Descope as Descope API
+
+    alt Password Authentication
+        User->>App: Enter email + password
+        App->>Descope: POST /auth/password/signin
+        Descope->>Descope: Validate credentials,<br/>check password policy
+        Descope->>App: Session JWT + Refresh JWT
+    else OTP (Email/SMS)
+        User->>App: Enter email/phone
+        App->>Descope: POST /auth/otp/signin
+        Descope->>User: Send OTP code
+        User->>App: Enter OTP code
+        App->>Descope: POST /auth/otp/verify
+        Descope->>App: Session JWT + Refresh JWT
+    else Magic Link
+        User->>App: Enter email
+        App->>Descope: POST /auth/magiclink/signin
+        Descope->>User: Send magic link email
+        User->>App: Click magic link
+        App->>Descope: Verify magic link token
+        Descope->>App: Session JWT + Refresh JWT
+    end
+
+    App->>User: Authenticated session
+```
+
+## Authorization Model
+
+How the three authorization layers compose:
+
+```mermaid
+graph TB
+    subgraph "Authorization Decision"
+        Decision[Access Granted?]
+    end
+
+    subgraph "Layer 1: RBAC"
+        User[User] --> ProjectRoles[Project Roles]
+        User --> TenantRoles[Tenant Roles]
+        ProjectRoles --> Permissions[Permissions]
+        TenantRoles --> Permissions
+    end
+
+    subgraph "Layer 2: FGA / ReBAC"
+        FGASchema[FGA Schema<br/>types + relations] --> Relations[Relations<br/>user:alice#owner@doc:1]
+        Relations --> FGACheck{FGA Check<br/>Is alice viewer of doc:1?}
+    end
+
+    subgraph "Layer 3: Lists"
+        IPList[IP Allowlist] --> IPCheck{IP in list?}
+        TextList[Text Denylist] --> TextCheck{Domain blocked?}
+    end
+
+    Permissions --> Decision
+    FGACheck --> Decision
+    IPCheck --> Decision
+    TextCheck --> Decision
+```
+
+## Terraform Resource Flow
+
+Which Terraform resources configure each part of the auth infrastructure:
+
+```mermaid
+graph LR
+    subgraph "Terraform-Managed Infrastructure"
+        Project[descope_project]
+        Tenant[descope_tenant]
+        Role[descope_role]
+        Perm[descope_permission]
+        SSO[descope_sso]
+        InApp[descope_inbound_application]
+        TPA[descope_third_party_application]
+        OutApp[descope_outbound_application]
+        PwdSettings[descope_password_settings]
+        FGA[descope_fga_schema]
+        List[descope_list]
+        AK[descope_access_key]
+        MK[descope_management_key]
+    end
+
+    subgraph "Runtime / Console-Managed"
+        Users[Users]
+        Flows[Auth Flows]
+        Sessions[Sessions]
+    end
+
+    Project --> Tenant
+    Project --> Role
+    Project --> Perm
+    Tenant --> SSO
+    Role --> Perm
+    Project --> InApp
+    Project --> TPA
+    Project --> OutApp
+    Project --> PwdSettings
+    Project --> FGA
+    Project --> List
+    Project --> AK
+    Project --> MK
+
+    InApp -.-> Users
+    Flows -.-> Users
+    Users -.-> Sessions
+```
+
+## Further Reading
+
+- [Descope Authentication Methods](https://docs.descope.com/auth-methods)
+- [Descope OIDC Endpoints](https://docs.descope.com/getting-started/oidc-endpoints)
+- [Descope Inbound Apps](https://docs.descope.com/identity-federation/inbound-apps/using-inbound-apps)
+- [Descope SSO Configuration](https://docs.descope.com/tenant-management/sso/how-authorization-works-with-sso-providers)
+- [Descope RBAC](https://docs.descope.com/authorization/role-based-access-control)
+- [Descope FGA/ReBAC](https://docs.descope.com/authorization/rebac)

--- a/docs/architecture/descope-model.md
+++ b/docs/architecture/descope-model.md
@@ -1,0 +1,112 @@
+# Descope Entity Model
+
+This document describes the Descope data model, how entities relate to each other, and which are managed by this Terraform provider.
+
+## Entity Relationship Diagram
+
+```mermaid
+erDiagram
+    Company ||--o{ Project : owns
+    Project ||--o{ Tenant : contains
+    Project ||--o{ Role : defines
+    Project ||--o{ Permission : defines
+    Project ||--o{ Flow : contains
+    Project ||--o{ JWTTemplate : configures
+    Project ||--o{ Connector : integrates
+    Project ||--o{ List : manages
+    Project ||--|| FGASchema : "has one"
+    Project ||--o{ InboundApp : registers
+    Project ||--o{ ThirdPartyApp : registers
+    Project ||--o{ OutboundApp : registers
+    Project ||--o{ SSOConfig : configures
+    Project ||--o{ ManagementKey : issues
+    Project ||--o{ AccessKey : issues
+    Project ||--o{ Descoper : manages
+    Project ||--|| PasswordSettings : configures
+
+    Tenant ||--o{ User : contains
+    Tenant ||--o{ Role : "has tenant-level"
+    Tenant ||--o{ SSOConfig : "has per-tenant"
+
+    Role ||--o{ Permission : includes
+    User }o--o{ Role : assigned
+    User }o--o{ Tenant : "belongs to"
+
+    InboundApp ||--o{ Scope : exposes
+    ThirdPartyApp ||--o{ Scope : exposes
+```
+
+## Entity Categories
+
+### Infrastructure (Terraform-Managed)
+
+These entities represent project configuration and are the natural domain of infrastructure-as-code:
+
+| Entity | Terraform Resource | Description |
+|--------|-------------------|-------------|
+| Project | `descope_project` | Top-level configuration unit. All other entities belong to a project. |
+| Tenant | `descope_tenant` | B2B multi-tenancy. Isolates users, roles, and SSO config. |
+| Role | `descope_role` | Authorization role. Can be project-level or tenant-level. |
+| Permission | `descope_permission` | Atomic authorization unit. Assigned to roles. |
+| Inbound Application | `descope_inbound_application` | OIDC/OAuth client registered to use Descope as IdP. |
+| Third-Party Application | `descope_third_party_application` | External OAuth client authenticating against Descope. |
+| Outbound Application | `descope_outbound_application` | OAuth client config for Descope to connect to external services. |
+| SSO Configuration | `descope_sso` | OIDC or SAML SSO provider configuration per tenant. |
+| Password Settings | `descope_password_settings` | Password policy (min length, complexity, lockout, expiration). |
+| Management Key | `descope_management_key` | API key for management operations. |
+| Access Key | `descope_access_key` | Service-to-service authentication token. |
+| Descoper | `descope_descoper` | Admin user with management console access. |
+| FGA Schema | `descope_fga_schema` | Fine-grained authorization schema (ReBAC relations). |
+| List | `descope_list` | IP allowlist/denylist or text-based filter list. |
+
+### Infrastructure (Data Sources)
+
+| Entity | Terraform Data Source | Description |
+|--------|----------------------|-------------|
+| Project Export | `descope_project_export` | Full project configuration snapshot as JSON. |
+| Password Settings | `descope_password_settings` | Read current password policy. |
+| FGA Check | `descope_fga_check` | Query FGA authorization for a relation tuple. |
+
+### Runtime (NOT Terraform-Managed)
+
+These entities are created and managed at application runtime, not during infrastructure provisioning:
+
+| Entity | Why Not Terraform | How to Manage |
+|--------|------------------|---------------|
+| Users | Runtime data created by user signups/logins. Managing users as TF resources would be like managing database rows in Terraform. | Descope SDKs, Management API, Console |
+| Flows | Visual authentication flows (screens, widgets, logic). Designed for the Descope console's drag-and-drop editor. | Descope Console, `descopecli` |
+| JWT Templates | Nested within project configuration. Already managed by the `descope_project` resource. | `descope_project` resource |
+| Connectors | Nested within project configuration (HTTP, SMTP, Twilio, etc.). Already managed by the `descope_project` resource. | `descope_project` resource |
+| Audit Events | Read-only operational log. Not infrastructure. | Management API, Console |
+
+## Key Relationships
+
+### Multi-Tenancy Model
+
+```
+Project
+  +-- Tenant A
+  |     +-- Users (subset)
+  |     +-- Tenant-level Roles
+  |     +-- SSO Config (SAML/OIDC)
+  +-- Tenant B
+  |     +-- Users (subset)
+  |     +-- Tenant-level Roles
+  |     +-- SSO Config
+  +-- Project-level Roles (shared across tenants)
+  +-- Project-level Permissions
+```
+
+A user can belong to multiple tenants with different roles in each. Project-level roles are inherited by all tenants.
+
+### Application Model
+
+- **Inbound Apps**: External applications that use Descope as an identity provider (IdP). Descope acts as the OAuth 2.0 Authorization Server.
+- **Third-Party Apps**: Similar to inbound apps but registered as third-party OAuth clients with consent flows.
+- **Outbound Apps**: Descope acts as an OAuth client to connect to external services (e.g., GitHub, Google) on behalf of users.
+
+### Authorization Layers
+
+1. **RBAC** (Roles + Permissions): Traditional role-based access. Roles contain permissions. Users are assigned roles at project or tenant level.
+2. **FGA/ReBAC** (Fine-Grained Authorization): Relationship-based access control with a schema defining object types and relations. Checked at runtime via the FGA Check API.
+3. **Lists**: IP and text allowlists/denylists for network-level and content-level filtering.

--- a/docs/architecture/oauth2-oidc-mapping.md
+++ b/docs/architecture/oauth2-oidc-mapping.md
@@ -1,0 +1,87 @@
+# OAuth 2.0 / OIDC to Descope Feature Mapping
+
+This document maps standard OAuth 2.0 and OpenID Connect (OIDC) specification concepts to their Descope implementations.
+
+## Grant Types
+
+| OAuth 2.0 Grant Type | RFC | Descope Implementation | Terraform Resource |
+|---|---|---|---|
+| **Authorization Code** | [RFC 6749 S4.1](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1) | Inbound/Third-Party Apps redirect users to Descope's `/authorize` endpoint. Descope authenticates the user via Flows and returns an authorization code. | `descope_inbound_application`, `descope_third_party_application` |
+| **Authorization Code + PKCE** | [RFC 7636](https://datatracker.ietf.org/doc/html/rfc7636) | Supported for public clients (non-confidential inbound apps). PKCE parameters passed in the authorization request. | `descope_inbound_application` (non_confidential_client) |
+| **Client Credentials** | [RFC 6749 S4.4](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4) | Access Keys provide service-to-service authentication. The access key ID and secret are used as client credentials. | `descope_access_key` |
+| **Device Authorization** | [RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628) | Not directly supported as a standard grant. Can be approximated with Descope Flows. | N/A |
+| **Token Exchange** | [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693) | Not directly supported. Descope uses its own session management model. | N/A |
+| **JWT Bearer** | [RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523) | Third-Party Apps support JWT Bearer settings for validating external tokens. | `descope_third_party_application` |
+
+## OIDC Core Concepts
+
+| OIDC Concept | Spec Reference | Descope Implementation |
+|---|---|---|
+| **ID Token** | [OIDC Core S2](https://openid.net/specs/openid-connect-core-1_0.html#IDToken) | Descope issues JWTs as session tokens. Claims are customizable via JWT Templates (configured in the project resource). |
+| **UserInfo Endpoint** | [OIDC Core S5.3](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo) | Available at `https://api.descope.com/oauth2/v1/userinfo`. Returns user profile data based on granted scopes. |
+| **Discovery** | [OIDC Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html) | Each project exposes `/.well-known/openid-configuration` with endpoints, supported scopes, and signing keys. |
+| **Standard Claims** | [OIDC Core S5.1](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims) | Descope maps user attributes (name, email, phone) to standard OIDC claims. Custom claims added via JWT Templates. |
+| **Dynamic Registration** | [OIDC Dynamic Registration](https://openid.net/specs/openid-connect-registration-1_0.html) | Not supported. Applications are registered via the Management API or Terraform. |
+
+## Token Management
+
+| Concept | Descope Implementation | Notes |
+|---|---|---|
+| **Access Token** | Descope session JWT | Short-lived token containing user claims, roles, permissions |
+| **Refresh Token** | Descope refresh JWT | Used to obtain new session tokens without re-authentication |
+| **Token Introspection** ([RFC 7662](https://datatracker.ietf.org/doc/html/rfc7662)) | Validate tokens via Descope SDKs or JWKS endpoint | Standard JWKS-based validation |
+| **Token Revocation** ([RFC 7009](https://datatracker.ietf.org/doc/html/rfc7009)) | Logout API / session management | Per-user or per-session revocation via Management API |
+| **Token Lifetime** | Configurable per inbound app | Session settings include token expiration and refresh token lifetime |
+
+## Client Types
+
+| OAuth 2.0 Client Type | Descope Equivalent | Terraform Resource |
+|---|---|---|
+| **Confidential Client** | Inbound App with `non_confidential_client = false` | `descope_inbound_application` |
+| **Public Client** | Inbound App with `non_confidential_client = true` | `descope_inbound_application` |
+| **Third-Party Client** | Third-Party Application (with consent flow) | `descope_third_party_application` |
+| **First-Party Client** | Direct Descope SDK integration (no OAuth needed) | N/A (SDK-based) |
+
+## Scopes and Claims
+
+| Concept | Descope Implementation |
+|---|---|
+| **`openid` scope** | Implicit in all OIDC flows. Returns ID token with `sub` claim. |
+| **`profile` scope** | Maps to user display name, given name, family name, picture. |
+| **`email` scope** | Maps to user email and email_verified. |
+| **`phone` scope** | Maps to user phone and phone_verified. |
+| **Custom scopes** | Defined as Permission Scopes on Inbound/Third-Party Apps. Mapped to Descope RBAC permissions. |
+| **Custom claims** | Added via JWT Templates in the project configuration. |
+
+## Federation and SSO
+
+| Standard | Descope Feature | Terraform Resource |
+|---|---|---|
+| **SAML 2.0 SP** | Descope acts as SAML Service Provider. Tenants configure their SAML IdP (Okta, Azure AD, etc.). | `descope_sso` (SAML settings) |
+| **OIDC RP** | Descope acts as OIDC Relying Party. Tenants configure their OIDC provider. | `descope_sso` (OIDC settings) |
+| **SAML IdP** | Descope acts as SAML Identity Provider via SSO Applications. | `descope_sso_application` (blocked - enterprise) |
+| **OIDC OP** | Descope acts as OIDC Provider via Inbound Applications. | `descope_inbound_application` |
+| **Social Login** | Outbound Apps connect to social providers (Google, GitHub, etc.). | `descope_outbound_application` |
+
+## Authorization
+
+| Concept | Descope Feature | Terraform Resource |
+|---|---|---|
+| **OAuth 2.0 Scopes** | Permission Scopes on Inbound/Third-Party Apps | `descope_inbound_application`, `descope_third_party_application` |
+| **RBAC** | Roles and Permissions (project-level and tenant-level) | `descope_role`, `descope_permission` |
+| **ReBAC / FGA** | Fine-Grained Authorization with Zanzibar-style relation schema | `descope_fga_schema`, `descope_fga_check` (data source) |
+| **ABAC** | User custom attributes + tenant attributes for attribute-based decisions | `descope_project` (user attributes config) |
+
+## Descope OIDC Endpoints
+
+For a project with ID `P123`, the OIDC endpoints are:
+
+| Endpoint | URL |
+|---|---|
+| Discovery | `https://api.descope.com/P123/.well-known/openid-configuration` |
+| Authorization | `https://api.descope.com/oauth2/v1/authorize` |
+| Token | `https://api.descope.com/oauth2/v1/token` |
+| UserInfo | `https://api.descope.com/oauth2/v1/userinfo` |
+| JWKS | `https://api.descope.com/P123/.well-known/jwks.json` |
+
+See [Descope OIDC Endpoints Quickstart](https://docs.descope.com/getting-started/oidc-endpoints) for details.


### PR DESCRIPTION
## Summary

Three new architecture documentation files with Mermaid diagrams:

### 1. Entity Model (`docs/architecture/descope-model.md`)
- Mermaid ER diagram showing all Descope entities and their relationships
- Table mapping every entity to its Terraform resource (or explaining why it's not TF-managed)
- Categories: Infrastructure (TF-managed), Data Sources, Runtime (not TF)

### 2. OAuth 2.0/OIDC Mapping (`docs/architecture/oauth2-oidc-mapping.md`)
- Maps every OAuth 2.0 grant type to Descope implementation
- OIDC Core concepts (ID tokens, UserInfo, Discovery, claims)
- Token management, client types, scopes, federation, authorization
- RFC references throughout
- OIDC endpoint URLs

### 3. Auth Flow Diagrams (`docs/architecture/auth-flows.md`)
- OAuth 2.0 Authorization Code flow (Descope as IdP)
- Third-party app consent flow
- SSO/SAML federation flow
- Standard auth (password/OTP/magic link)
- Authorization model composition (RBAC + FGA + Lists)
- Terraform resource mapping diagram

Automated PR from ralph loop task T81. Closes #93

## Test plan

- [x] Pure documentation — no code changes
- [x] Mermaid diagrams render on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)