### PR TITLE
chore: sync upstream (CI action bumps)

### DIFF
--- a/.github/actions/ci/lint/action.yml
+++ b/.github/actions/ci/lint/action.yml
@@ -11,5 +11,5 @@ runs:
     - name: Run Linter
       uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
       with:
-        version: v2.10.1
+        version: v2.11.0
         args: --config=.github/actions/ci/lint/golangci.yml

--- a/.github/actions/ci/lint/action.yml
+++ b/.github/actions/ci/lint/action.yml
@@ -11,5 +11,5 @@ runs:
     - name: Run Linter
       uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
       with:
-        version: v2.11.2
+        version: v2.11.3
         args: --config=.github/actions/ci/lint/golangci.yml

--- a/.github/actions/ci/lint/action.yml
+++ b/.github/actions/ci/lint/action.yml
@@ -11,5 +11,5 @@ runs:
     - name: Run Linter
       uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
       with:
-        version: v2.11.1
+        version: v2.11.2
         args: --config=.github/actions/ci/lint/golangci.yml

--- a/.github/actions/ci/lint/action.yml
+++ b/.github/actions/ci/lint/action.yml
@@ -11,5 +11,5 @@ runs:
     - name: Run Linter
       uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
       with:
-        version: v2.11.0
+        version: v2.11.1
         args: --config=.github/actions/ci/lint/golangci.yml

--- a/.github/actions/ci/setup/action.yml
+++ b/.github/actions/ci/setup/action.yml
@@ -6,7 +6,7 @@ runs:
   using: composite
   steps:
     - name: Setup Go
-      uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: go.mod
         cache: false

--- a/.github/actions/ci/setup/action.yml
+++ b/.github/actions/ci/setup/action.yml
@@ -12,7 +12,7 @@ runs:
         cache: false
 
     - name: Enable Cache
-      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: |
           ~/go/pkg/mod


### PR DESCRIPTION
## Summary
Sync fork with `descope/terraform-provider-descope` main. Pulls in 6 upstream commits; only one file changes in the merge (the rest were already merged via #140).

Changes:
- `actions/setup-go`: v6.3.0 → v6.4.0 (upstream #275)
- `actions/cache`: v5.0.3 → v5.0.4 (upstream #276)

Also included (no file delta — already merged via #140):
- golangci-lint v2.11.0 → v2.11.3 (upstream #269–#272)

## Test plan
- [ ] CI green on this branch