### PR TITLE
ci: consolidate dependabot into grouped daily PRs + auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,24 +1,44 @@
 version: 2
+# Dependabot runs daily and bundles every routine update into a single grouped
+# PR per ecosystem via `groups:` below. A dedicated dependabot-auto-merge.yml
+# workflow enables `gh pr merge --auto --squash` on these PRs so they merge
+# themselves once all required CI stages pass. Security alerts continue to
+# arrive as standalone PRs outside the group.
 updates:
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: weekly
-      day: monday
-    open-pull-requests-limit: 10
+      interval: daily
+      time: "03:00"
+      timezone: UTC
+    open-pull-requests-limit: 1
     commit-message:
       prefix: "build(deps)"
+      include: scope
     labels:
       - dependencies
+      - go
+    groups:
+      go-modules:
+        applies-to: version-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
-      day: monday
-    open-pull-requests-limit: 5
+      interval: daily
+      time: "03:00"
+      timezone: UTC
+    open-pull-requests-limit: 1
     commit-message:
       prefix: "ci(deps)"
+      include: scope
     labels:
       - dependencies
       - ci
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,27 @@
+name: Dependabot Auto-merge
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    # Only run on PRs actually opened by dependabot.
+    if: github.actor == 'dependabot[bot]' && github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge (squash)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/scripts/mirror-dependabot-secrets.sh
+++ b/scripts/mirror-dependabot-secrets.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Mirror the repo secrets that CI references into the Dependabot secret scope
+# so dependabot-authored PRs can run the full integration suite. Run once per
+# repo; re-run on value rotation or when CI references a new secret.
+#
+# GitHub does not let any principal read an existing secret value, so this
+# script reads required values from the current shell environment. Populate
+# the shell first:
+#
+#     source .env
+#
+# Alternatively export each variable by hand or pull from a secret store.
+#
+# Usage:
+#   ./scripts/mirror-dependabot-secrets.sh
+#
+# Requires: `gh` authenticated as a repo admin on the target repo.
+
+set -euo pipefail
+
+REPO="${REPO:-jamescrowley321/terraform-provider-descope}"
+
+SECRETS=(
+  DESCOPE_MANAGEMENT_KEY
+  DESCOPE_PROJECT_ID
+)
+
+missing=()
+for name in "${SECRETS[@]}"; do
+  if [[ -z "${!name:-}" ]]; then
+    missing+=("$name")
+  fi
+done
+
+if (( ${#missing[@]} > 0 )); then
+  printf 'ERROR: the following env vars are not set in the current shell:\n' >&2
+  printf '  %s\n' "${missing[@]}" >&2
+  printf '\nExport them (e.g. `source .env`) then re-run this script.\n' >&2
+  exit 1
+fi
+
+printf 'Mirroring %d secrets to Dependabot scope on %s...\n' "${#SECRETS[@]}" "$REPO"
+for name in "${SECRETS[@]}"; do
+  printf '%s' "${!name}" | gh secret set "$name" --app dependabot --repo "$REPO"
+  printf '  set %s\n' "$name"
+done
+
+printf '\nDone. Verify with:\n  gh api repos/%s/dependabot/secrets\n' "$REPO"


### PR DESCRIPTION
## Summary

Collapse dependabot into **one grouped PR per ecosystem per day** and let those PRs auto-merge once all required CI stages pass.

**Before:**
- Weekly dependabot schedule producing up to 15 PRs per week (10 gomod + 5 github-actions).
- No auto-merge — every PR required manual review and click even when CI was green.
- `Integration Tests (upstream)` fails on every dependabot PR because `DESCOPE_MANAGEMENT_KEY` / `DESCOPE_PROJECT_ID` don't exist in the Dependabot secret scope (confirmed via [PR #134](https://github.com/jamescrowley321/terraform-provider-descope/pull/134) status checks — upstream failed, fork skipped, everything else green).

**After:**
- Daily schedule, `groups:` config bundles every routine update into one rolling PR per ecosystem.
- `dependabot-auto-merge.yml` runs `gh pr merge --auto --squash` on dependabot PRs. It only fires when `github.actor == 'dependabot[bot]'`.
- `scripts/mirror-dependabot-secrets.sh` mirrors `DESCOPE_MANAGEMENT_KEY` and `DESCOPE_PROJECT_ID` from your shell env into the Dependabot scope in one command.

SonarCloud and Snyk already work on dependabot PRs here because they're GitHub Apps rather than workflow secrets — no extra wiring needed for them.

## Manual follow-up after merge

Order matters — auto-merge is a no-op until these are done:

1. **Mirror secrets to Dependabot scope:**
   ```bash
   source .env
   ./scripts/mirror-dependabot-secrets.sh
   ```
2. **Wait for the next dependabot PR** and confirm `Integration Tests (upstream)` + `Integration Tests (fork)` go green.
3. **Enable required status checks on `main`.** Currently `required_status_checks: null`. Suggested set (confirm from the green PR first):
   - `Build and Setup`
   - `Unit Tests`
   - `Run Linter`
   - `Check Leaks`
   - `Integration Tests (upstream)`
   - `Integration Tests (fork)`
   - `gosec`
   - `govulncheck`
   - `Snyk Security Scan`
   - `Analyze`
   - `SonarCloud Code Analysis`
4. Done — next dependabot PR will auto-merge when CI goes green.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go build ./...` clean
- [ ] Post-merge: verify next dependabot PR bundles all updates into one PR per ecosystem
- [ ] Post-merge: verify auto-merge workflow fires on a dependabot PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)