### PR TITLE
chore: post-sync quality & security hardening (Sonar + Snyk gate)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -81,15 +81,22 @@ jobs:
       - name: Install Snyk CLI
         uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
 
+      # Fail loudly if the token is missing rather than silently skipping the
+      # scan, which would leave this required check as a no-op pass.
+      - name: Verify Snyk token is configured
+        run: |
+          if [ -z "$SNYK_TOKEN" ]; then
+            echo "::error::SNYK_TOKEN secret is not set — Snyk scanning is disabled. Add the SNYK_TOKEN repository secret to enable it."
+            exit 1
+          fi
+
       - name: Snyk Open Source (SCA)
-        if: env.SNYK_TOKEN != ''
         run: snyk test --severity-threshold=high
 
       - name: Snyk Code (SAST)
-        if: env.SNYK_TOKEN != ''
         run: snyk code test
 
       - name: Snyk Monitor
-        if: env.SNYK_TOKEN != '' && github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         run: snyk monitor
 

--- a/internal/models/attrs/stringattr/validators.go
+++ b/internal/models/attrs/stringattr/validators.go
@@ -14,6 +14,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
+// logValidatingString is the trace message emitted at the start of each string validator.
+const logValidatingString = "Validating string"
+
 var TimeUnitValidator = stringvalidator.OneOf("seconds", "minutes", "hours", "days", "weeks")
 
 var StandardLenValidator = stringvalidator.LengthAtMost(254)
@@ -44,7 +47,7 @@ func (v nonEmptyValidator) MarkdownDescription(ctx context.Context) string {
 }
 
 func (v nonEmptyValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
-	tflog.Trace(ctx, "Validating string", map[string]any{"path": req.Path.String()})
+	tflog.Trace(ctx, logValidatingString, map[string]any{"path": req.Path.String()})
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
 	}
@@ -70,7 +73,7 @@ func (v jsonValidator) MarkdownDescription(ctx context.Context) string {
 }
 
 func (v jsonValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
-	tflog.Trace(ctx, "Validating string", map[string]any{"path": req.Path.String()})
+	tflog.Trace(ctx, logValidatingString, map[string]any{"path": req.Path.String()})
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
 	}
@@ -107,7 +110,7 @@ func (v emailValidator) MarkdownDescription(ctx context.Context) string {
 }
 
 func (v emailValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
-	tflog.Trace(ctx, "Validating string", map[string]any{"path": req.Path.String()})
+	tflog.Trace(ctx, logValidatingString, map[string]any{"path": req.Path.String()})
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
 	}

--- a/internal/models/project/applications/ssoroles.go
+++ b/internal/models/project/applications/ssoroles.go
@@ -131,26 +131,40 @@ func (m *SSOAppRoleModel) SetValues(h *helpers.Handler, data map[string]any) {
 	stringattr.Set(&m.Description, data, "description")
 
 	if raw, ok := data["permissions"].([]any); ok {
-		names := make([]any, 0, len(raw))
-		for _, item := range raw {
-			if perm, ok := item.(map[string]any); ok {
-				if name, ok := perm["name"].(string); ok && name != "" {
-					names = append(names, name)
-				}
-			}
-		}
+		names := ssoAppPermissionNames(raw)
 		strsetattr.Set(&m.Permissions, map[string]any{"permissions": names}, "permissions", h)
 	}
 
 	if raw, ok := data["roleMappings"].([]any); ok {
-		values := make([]any, 0, len(raw))
-		for _, item := range raw {
-			if v, ok := item.(string); ok && v != "" {
-				values = append(values, v)
-			}
-		}
+		values := ssoAppRoleMappingValues(raw)
 		strsetattr.Set(&m.RoleMappings, map[string]any{"roleMappings": values}, "roleMappings", h)
 	}
+}
+
+// ssoAppPermissionNames extracts the non-empty "name" field from a list of permission objects.
+func ssoAppPermissionNames(raw []any) []any {
+	names := make([]any, 0, len(raw))
+	for _, item := range raw {
+		perm, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if name, ok := perm["name"].(string); ok && name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// ssoAppRoleMappingValues extracts non-empty string identifiers from a raw list.
+func ssoAppRoleMappingValues(raw []any) []any {
+	values := make([]any, 0, len(raw))
+	for _, item := range raw {
+		if v, ok := item.(string); ok && v != "" {
+			values = append(values, v)
+		}
+	}
+	return values
 }
 
 func (m *SSOAppRoleModel) GetName() stringattr.Type {

--- a/internal/resources/base.go
+++ b/internal/resources/base.go
@@ -15,6 +15,9 @@ import (
 	"github.com/jamescrowley321/terraform-provider-descope/internal/models/helpers"
 )
 
+// logResourceSuffix is appended to lifecycle log messages, e.g. "Creating access_key resource".
+const logResourceSuffix = " resource"
+
 // Creates a new resource with the given name. If the schema contains a `project_id` attribute then
 // the resource will be assumed to be a project-level resource (like a connector or flow), otherwise
 // it'll be assumed to be a company-level resource.
@@ -50,7 +53,7 @@ func (r *baseResource[T, M]) Schema(_ context.Context, _ resource.SchemaRequest,
 }
 
 func (r *baseResource[T, M]) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	tflog.Info(ctx, "Creating "+r.name+" resource")
+	tflog.Info(ctx, "Creating "+r.name+logResourceSuffix)
 
 	model := M(new(T))
 	resp.Diagnostics.Append(req.Plan.Get(ctx, model)...)
@@ -78,11 +81,11 @@ func (r *baseResource[T, M]) Create(ctx context.Context, req resource.CreateRequ
 	model.SetValues(handler, res.Data)
 	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
 
-	tflog.Info(ctx, "Created "+r.name+" resource")
+	tflog.Info(ctx, "Created "+r.name+logResourceSuffix)
 }
 
 func (r *baseResource[T, M]) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	tflog.Info(ctx, "Reading "+r.name+" resource")
+	tflog.Info(ctx, "Reading "+r.name+logResourceSuffix)
 	ctx = helpers.ContextWithImportState(ctx, req, resp)
 
 	model := M(new(T))
@@ -101,11 +104,11 @@ func (r *baseResource[T, M]) Read(ctx context.Context, req resource.ReadRequest,
 	model.SetValues(handler, res.Data)
 	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
 
-	tflog.Info(ctx, "Read "+r.name+" resource")
+	tflog.Info(ctx, "Read "+r.name+logResourceSuffix)
 }
 
 func (r *baseResource[T, M]) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	tflog.Info(ctx, "Updating "+r.name+" resource")
+	tflog.Info(ctx, "Updating "+r.name+logResourceSuffix)
 
 	model := M(new(T))
 	resp.Diagnostics.Append(req.Plan.Get(ctx, model)...)
@@ -132,11 +135,11 @@ func (r *baseResource[T, M]) Update(ctx context.Context, req resource.UpdateRequ
 	model.SetValues(handler, res.Data)
 	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
 
-	tflog.Info(ctx, "Updated "+r.name+" resource")
+	tflog.Info(ctx, "Updated "+r.name+logResourceSuffix)
 }
 
 func (r *baseResource[T, M]) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	tflog.Info(ctx, "Deleting "+r.name+" resource")
+	tflog.Info(ctx, "Deleting "+r.name+logResourceSuffix)
 
 	model := M(new(T))
 	resp.Diagnostics.Append(req.State.Get(ctx, model)...)
@@ -150,11 +153,11 @@ func (r *baseResource[T, M]) Delete(ctx context.Context, req resource.DeleteRequ
 		return
 	}
 
-	tflog.Info(ctx, "Deleted "+r.name+" resource")
+	tflog.Info(ctx, "Deleted "+r.name+logResourceSuffix)
 }
 
 func (r *baseResource[T, M]) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	tflog.Info(ctx, "Importing "+r.name+" resource")
+	tflog.Info(ctx, "Importing "+r.name+logResourceSuffix)
 	helpers.MarkImportState(ctx, resp)
 
 	if _, ok := r.schema.Attributes["project_id"]; !ok {

--- a/internal/resources/passwordsettings.go
+++ b/internal/resources/passwordsettings.go
@@ -14,6 +14,11 @@ import (
 	"github.com/jamescrowley321/terraform-provider-descope/internal/models/passwordsettings"
 )
 
+// passwordSettingsID is the fixed Terraform resource ID for the singleton
+// password_settings resource. It is an entity name used for API routing, not a
+// credential; the directive below suppresses Snyk Code's false-positive
+// hardcoded-secret finding (CWE-798) on the constant name.
+// deepcode ignore HardcodedNonCryptoSecret: entity name for the password_settings resource, not a secret
 const passwordSettingsID = "password_settings"
 
 var (


### PR DESCRIPTION
Stacked on #168 (the upstream sync). Resolves the SonarCloud findings and the Snyk findings surfaced on that PR, plus fixes a no-op Snyk CI gate. Rebase onto `main` once #168 merges.

## SonarCloud — resolve the 3 inherited findings
All three were introduced by the upstream sync (code adopted from upstream):
- **`base.go` (S1192):** extract `logResourceSuffix` const for the `" resource"` literal duplicated across the 9 lifecycle log lines.
- **`stringattr/validators.go` (S1192):** extract `logValidatingString` const for the `"Validating string"` trace literal (×3).
- **`applications/ssoroles.go` (S3776):** reduce `SetValues` cognitive complexity (18 → within the 15 limit) by extracting the permission-name and role-mapping loops into helpers.

No behavior change; build/vet/unit tests/govulncheck all clean.

## Snyk — the findings were Snyk **Code** (SAST), not dependency vulns
That's why `govulncheck`, `osv-scanner`, and Snyk's package DB were all clean — they only do SCA. The two findings:
- **Low — `models/accesskey/convert_test.go` (hardcoded credential):** already resolved by #168, which deleted that file.
- **Medium — `resources/passwordsettings.go` (hardcoded password):** **false positive.** `const passwordSettingsID = "password_settings"` is the singleton resource's fixed Terraform ID / API entity name, not a credential — Snyk's heuristic only trips because the identifier name contains "password". Documented the constant and added an inline `deepcode ignore` directive.

> ⚠️ I can't verify the exact `deepcode ignore` rule slug clears it without Snyk access — please confirm against the finding's rule, or use the one-click **Ignore** in the Snyk UI (canonical for false positives). A `SNYK_TOKEN` would let CI verify automatically.

## Snyk — fix the no-op CI gate
The required **"Snyk Security Scan"** job gated every step on `if: env.SNYK_TOKEN != ''`, and **no `SNYK_TOKEN` secret is configured**, so all steps skipped and the job passed as a 13s no-op — it wasn't scanning anything. This PR adds an explicit token-presence check that **fails the job** when the secret is unset, and removes the per-step guards so `snyk test`/`snyk code test` actually run once the secret exists. `snyk monitor` stays on `main`.

> ⚠️ **Action required:** add the `SNYK_TOKEN` repository secret (`gh secret set SNYK_TOKEN`) for this job to go green. Until then it will (intentionally) fail, signalling the gate is unconfigured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)