### PR TITLE
ci(release): replace broken SLSA generator with native build provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    outputs:
-      hashes: ${{ steps.hash.outputs.hashes }}
+      id-token: write # keyless signing of the build provenance attestation
+      attestations: write # write the build provenance attestation
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -46,21 +46,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
 
-      - name: Generate SLSA Subject Hashes
-        id: hash
-        run: |
-          cd dist
-          sha256sum *.zip *.json > checksums.txt
-          echo "hashes=$(base64 -w0 checksums.txt)" >> "$GITHUB_OUTPUT"
-
-  provenance:
-    name: Generate SLSA Provenance
-    needs: goreleaser
-    permissions:
-      actions: read
-      contents: write
-      id-token: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
-    with:
-      base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
-      upload-assets: true
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: dist/*.zip


### PR DESCRIPTION
## Problem

The post-merge **Release** run for `v1.2.0` failed in the **Generate SLSA Provenance** job ([run](https://github.com/jamescrowley321/terraform-provider-descope/actions/runs/28405962560)):

```
Input required and not supplied: path
Process completed with exit code 127
```

The vendored `slsa-framework/slsa-github-generator@v2.1.0` reusable workflow runs internal actions that target Node 20; GitHub now force-migrates those to Node 24, breaking the generator. GoReleaser itself succeeded — `v1.2.0` is published with all platform zips + GPG-signed `SHA256SUMS`, so the release is complete and registry-installable. Only the supply-chain attestation was lost.

## Fix

Replace the broken two-job SLSA setup with GitHub's first-party [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance), run as a single step in the `goreleaser` job after the build:

- Node-24 compatible and actively maintained (no recurrence of this rot)
- Produces SLSA-3 provenance, verifiable with `gh attestation verify <zip>`
- Adds `id-token: write` + `attestations: write` to the job; drops the unused subject-hash step and the separate `provenance` job (net −14 lines)

## Notes

- Provenance is supply-chain hardening, not a registry requirement — the registry only needs the GPG-signed `SHA256SUMS`, which is unaffected.
- After merge, re-running the Release workflow for `v1.2.0` will backfill its provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)