### PR TITLE
ci(release): generate SPDX SBOMs for provider release archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,10 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
+      # GoReleaser's `sboms` stage shells out to `syft`; install it first.
+      - name: Install Syft (SBOM generation)
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
       - name: Run GoReleaser
         id: goreleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,6 +36,13 @@ archives:
   - format: zip
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
+# SPDX SBOM per release archive (syft's default format; syft is installed in
+# the release workflow before GoReleaser runs). Emitted alongside the provider
+# archives so consumers get a bill of materials. The Terraform Registry ingests
+# only the zips + SHA256SUMS + manifest and ignores the extra .sbom.json files.
+sboms:
+  - artifacts: archive
+
 checksum:
   extra_files:
     - glob: "terraform-registry-manifest.json"


### PR DESCRIPTION
Tier-2 §3 for terraform-provider-descope: add an SBOM to each release (this repo already does `attest-build-provenance`).

## Change
- `.goreleaser.yml`: add a `sboms` stage (`artifacts: archive`) → one **SPDX-2.3** SBOM (`.zip.sbom.json`) per provider archive, via syft.
- `.github/workflows/release.yml`: install syft (`anchore/sbom-action/download-syft`, SHA-pinned) before GoReleaser, since goreleaser shells out to `syft`.

## Registry safety
The Terraform Registry ingests only the `_{os}_{arch}.zip` archives + `SHA256SUMS` (+ `.sig`) + manifest and ignores extra files, so the `.sbom.json` artifacts are additive and non-breaking.

## Validation
Release jobs only run on tag, so PR CI can't exercise the end-to-end path. Validated **locally** instead against this exact config:
- `goreleaser release --snapshot --skip=publish,sign` → **12 `.zip.sbom.json` (SPDX-2.3) files produced**, one per archive.
- `goreleaser check` → config valid (the only `check` warning is a pre-existing `archives.format` deprecation, unrelated to this change and not flagged by the CI's pinned goreleaser).
- `actionlint` clean.

`ci`-typed so release-please does not cut a version bump. Next actual release exercises the full path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)