### PR TITLE
docs: correct provider scope in index — tenants are managed, not excluded

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ description: |-
 
 The [Descope](https://www.descope.com) Terraform Provider lets you manage your Descope project configuration as infrastructure-as-code. Configure authentication methods, define roles and permissions, set up third-party connectors, manage flows, and more—all declaratively in Terraform.
 
-Descope is an authentication and user management platform. The Terraform provider manages _project configuration_ (how your project behaves), not users or tenants (use the [Descope Management API](https://docs.descope.com/api/openapi) or [SDKs](https://docs.descope.com) for those).
+Descope is an authentication and user management platform. This provider manages your Descope project configuration as infrastructure — projects, tenants, roles, permissions, SSO, connectors, applications, and access keys. It intentionally does **not** manage end users, which are runtime entities created through authentication flows (use the [Descope Management API](https://docs.descope.com/api/openapi) or [SDKs](https://docs.descope.com) for those).
 
 ## Requirements
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -8,7 +8,7 @@ description: |-
 
 The [Descope](https://www.descope.com) Terraform Provider lets you manage your Descope project configuration as infrastructure-as-code. Configure authentication methods, define roles and permissions, set up third-party connectors, manage flows, and more—all declaratively in Terraform.
 
-Descope is an authentication and user management platform. The Terraform provider manages _project configuration_ (how your project behaves), not users or tenants (use the [Descope Management API](https://docs.descope.com/api/openapi) or [SDKs](https://docs.descope.com) for those).
+Descope is an authentication and user management platform. This provider manages your Descope project configuration as infrastructure — projects, tenants, roles, permissions, SSO, connectors, applications, and access keys. It intentionally does **not** manage end users, which are runtime entities created through authentication flows (use the [Descope Management API](https://docs.descope.com/api/openapi) or [SDKs](https://docs.descope.com) for those).
 
 ## Requirements
 


### PR DESCRIPTION
## What
The generated provider index page (`docs/index.md`) and its source template (`templates/index.md.tmpl`) both stated the provider manages *"project configuration ... not users or **tenants**."* That sentence is inherited from upstream and is **wrong for this fork**.

`descope_tenant` is a first-class resource here — it's one of the resources this fork *added* on top of upstream (see README resource table), alongside roles, permissions, SSO, applications, and access keys.

## Fix
Rewrote the scope sentence to match reality and the README's own framing (only **end users** are intentionally excluded, because they're runtime entities). Edited **both** the `.tmpl` source and the generated `docs/index.md` identically — the text is copied verbatim by `tfplugindocs`, so this is equivalent to a regenerate (`tfplugindocs` isn't installed locally to run `make docs`; template and output verified byte-identical).

## Audit note
The rest of this repo's docs are in good shape: README resource/data-source counts reconcile exactly with `internal/models/` (15 + 4), the `architecture/` docs list current resource names correctly, and the registry `source = "jamescrowley321/descope"` is published. This was the one substantive inaccuracy found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)