### PR TITLE
fix: bump Go toolchain to 1.26.6 to patch stdlib vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jamescrowley321/terraform-provider-descope
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/descope/go-sdk v1.28.0


### PR DESCRIPTION
## What

Bumps the `go` directive in `go.mod` from `1.26.5` → `1.26.6`. All CI workflows resolve their Go version via `go-version-file: go.mod`, so this bumps the toolchain used by every job including `govulncheck`.

## Why

The required `govulncheck` check was **failing on both open dependabot PRs** (#195, #192), blocking them from merging. The failures are Go **standard-library** vulnerabilities — none addressed by the dependency bumps themselves — all *Fixed in go1.26.6*:

| Advisory | Package | Reachable via |
|---|---|---|
| GO-2026-6218 | `net/url` | `http.Client.Do` |
| GO-2026-6090 | `crypto/tls` | `providerserver.Serve`, `http.Client.Do` |
| GO-2026-5972 | `encoding/asn1` | `providerserver.Serve` |
| GO-2026-5026 | `net/http` | `http.Client.Do` |

## Verification (local, under go1.26.6)

- `go build ./...` — clean
- `govulncheck ./...` — **No vulnerabilities found** (exit 0)

## Impact

Unblocks dependabot #195 (go-modules) and #192 (github-actions), which were blocked solely by this orthogonal toolchain vuln.

🤖 Generated with [Claude Code](https://claude.com/claude-code)