### PR TITLE
ci: add adversarial review merge gate

### DIFF
--- a/.github/workflows/adversarial-review.yml
+++ b/.github/workflows/adversarial-review.yml
@@ -1,0 +1,119 @@
+# Adversarial Review — fresh-context, diff-only AI PR review that fails the merge
+# on real defects. https://github.com/jamescrowley321/adversarial-review
+#
+# Setup: add repo secret OPENROUTER_API_KEY; then require the "Merge Gate" check
+# in branch protection. Toggle lenses in the ENABLED list below (one source of
+# truth for the matrix + gate). Action pinned to a commit SHA (v1.6.0).
+
+name: Adversarial Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+
+concurrency:
+  group: adversarial-review-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  issues: read
+
+jobs:
+  config:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.pick.outputs.matrix }}
+      csv: ${{ steps.pick.outputs.csv }}
+    steps:
+      - id: pick
+        shell: node {0}
+        env:
+          ENABLED: |
+            blind          # logic bugs, footguns (zero context)
+            edge-case      # unhandled branches / boundaries
+            acceptance     # PR acceptance criteria met + tested
+            sentinel       # exploitable security vulnerabilities
+            viper          # red-team attack paths (auth/infra)
+            compliance     # AI-provenance policy + repo rules
+        run: |
+          const NAMES = {
+            blind: "Blind Hunter", "edge-case": "Edge Case Hunter",
+            acceptance: "Acceptance Auditor", sentinel: "Sentinel", viper: "Viper",
+            compliance: "Compliance Auditor",
+          };
+          const keys = (process.env.ENABLED || "").split("\n")
+            .map((l) => l.replace(/#.*/, "").trim()).filter(Boolean);
+          const include = keys.map((k) => ({ lens: k, name: NAMES[k] || k }));
+          const fs = require("fs");
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `matrix=${JSON.stringify({ include })}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `csv=${keys.join(",")}\n`);
+
+  preflight:
+    name: Preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: >-
+      github.event.pull_request.head.repo.fork == false &&
+      github.actor != 'dependabot[bot]'
+    permissions:
+      checks: read
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Wait for deterministic checks
+        uses: jamescrowley321/adversarial-review@7d18b99faf7567366b5091deaf1470692d668245 # v1.6.0
+        with:
+          mode: preflight
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          required_checks: "Run Linter, Unit Tests, Check Leaks, gosec"
+
+  review:
+    name: ${{ matrix.name }}
+    needs: [config, preflight]
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.config.outputs.matrix) }}
+    steps:
+      - name: ${{ matrix.name }}
+        uses: jamescrowley321/adversarial-review@7d18b99faf7567366b5091deaf1470692d668245 # v1.6.0
+        with:
+          mode: lens
+          lens: ${{ matrix.lens }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          model: anthropic/claude-sonnet-5
+          models_config: |
+            {
+              "providers": {
+                "openrouter": {
+                  "modelOverrides": {
+                    "anthropic/claude-sonnet-5": {
+                      "compat": { "openRouterRouting": { "sort": "price", "zdr": true } }
+                    }
+                  }
+                }
+              }
+            }
+
+  gate:
+    name: Merge Gate
+    needs: [config, review]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: always() && needs.review.result != 'skipped'
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Adjudicate lenses
+        uses: jamescrowley321/adversarial-review@7d18b99faf7567366b5091deaf1470692d668245 # v1.6.0
+        with:
+          mode: gate
+          lenses: ${{ needs.config.outputs.csv }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/adversarial-review.yml
+++ b/.github/workflows/adversarial-review.yml
@@ -47,6 +47,10 @@ jobs:
           };
           const keys = (process.env.ENABLED || "").split("\n")
             .map((l) => l.replace(/#.*/, "").trim()).filter(Boolean);
+          if (keys.length === 0) {
+            core.setFailed("ENABLED must list at least one lens; an empty matrix would fail workflow validation with an opaque error.");
+            return;
+          }
           const include = keys.map((k) => ({ lens: k, name: NAMES[k] || k }));
           const fs = require("fs");
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `matrix=${JSON.stringify({ include })}\n`);
@@ -56,9 +60,10 @@ jobs:
     name: Preflight
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: >-
-      github.event.pull_request.head.repo.fork == false &&
-      github.actor != 'dependabot[bot]'
+    # Auto-review runs ONLY for PRs authored by the repo owner. Collaborators,
+    # outside contributors, forks, and bots skip the paid lenses; the gate then
+    # fails closed (below), so those PRs require manual owner review + merge.
+    if: github.event.pull_request.author_association == 'OWNER'
     permissions:
       checks: read
       contents: read
@@ -103,15 +108,28 @@ jobs:
 
   gate:
     name: Merge Gate
-    needs: [config, review]
+    needs: [config, preflight, review]
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: always() && needs.review.result != 'skipped'
+    # Always run so the required "Merge Gate" check is never absent or skipped.
+    # Branch protection treats a skipped required check as passing, so a gate
+    # that skips for non-owner PRs (whose review is skipped) would let them merge
+    # with zero review. Fail closed instead — non-owner PRs require manual review.
+    if: always()
     permissions:
       contents: read
       pull-requests: read
     steps:
+      # review is 'skipped' for non-owner PRs (only owner PRs are auto-reviewed)
+      # and 'failure' if a lens leg crashed. Either way, don't adjudicate a
+      # partial/absent lens set — fail closed so the owner reviews and merges.
+      - name: Fail closed when review did not complete
+        if: needs.review.result != 'success'
+        run: |
+          echo "::error::Adversarial review did not complete (non-owner PR, or a lens failed: review=${{ needs.review.result }}). Only owner PRs are auto-reviewed; others require manual owner review + merge. The Merge Gate fails closed."
+          exit 1
       - name: Adjudicate lenses
+        if: needs.review.result == 'success'
         uses: jamescrowley321/adversarial-review@7d18b99faf7567366b5091deaf1470692d668245 # v1.6.0
         with:
           mode: gate

--- a/.github/workflows/adversarial-review.yml
+++ b/.github/workflows/adversarial-review.yml
@@ -7,6 +7,12 @@
 
 name: Adversarial Review
 
+# Security model: this is a `pull_request` (NOT pull_request_target) workflow, so
+# it never runs with secrets for fork PRs — GitHub withholds all secrets and makes
+# GITHUB_TOKEN read-only for forks. A forked PR that edits this file therefore
+# cannot read OPENROUTER_API_KEY or forge a check run. Combined with the owner-only
+# guard on `preflight` below, the secret-bearing lens jobs run only for the owner's
+# own PRs; everyone else fails closed at the gate.
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -25,6 +31,7 @@ permissions:
 jobs:
   config:
     runs-on: ubuntu-latest
+    permissions: {} # computes the lens matrix only — no API access needed
     outputs:
       matrix: ${{ steps.pick.outputs.matrix }}
       csv: ${{ steps.pick.outputs.csv }}


### PR DESCRIPTION
Wires **[jamescrowley321/adversarial-review@v1.6.0](https://github.com/jamescrowley321/adversarial-review)** (pinned to its commit SHA) as a fresh-context AI PR review gate: `config → preflight → parallel lens matrix → Merge Gate` (fail-closed).

- **Owner-only auto-review.** The paid lenses run **only for PRs authored by the repo owner** (`author_association == 'OWNER'`). Collaborators, outside contributors, forks, and bots skip the lenses, and the Merge Gate **fails closed** — so their PRs require manual owner review + merge, never an automated pass.
- **Lenses:** blind, edge-case, acceptance, sentinel, viper, compliance (owasp-web dropped — this is a library/provider, not a web app).
- **Preflight** waits on this repo's deterministic checks so paid lenses never run on a red PR.
- **Fail-closed gate.** The Merge Gate always runs and fails whenever the review didn't complete (non-owner PR, or a crashed lens leg) — otherwise a skipped required check counts as passing in branch protection.
- **Model** `anthropic/claude-sonnet-5` via OpenRouter (ZDR + price-sort). Gate job is read-only; pinned to a commit SHA for OpenSSF Scorecard.

### Security model
This is a `pull_request` (not `pull_request_target`) workflow. GitHub withholds all secrets and forces a read-only `GITHUB_TOKEN` for fork PRs, so a forked PR that edits this file cannot exfiltrate `OPENROUTER_API_KEY` or forge a check run. The secret-bearing lens jobs run only for owner-authored PRs.

## Owner setup
1. Repo secret `OPENROUTER_API_KEY` — set.
2. After the first green run, require the `Merge Gate` check in branch protection for `main`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model: Claude Opus 4.8 (1M context) (`claude-opus-4-8`)
Accountable maintainer: @jamescrowley321 (owner; reviews and merges manually)